### PR TITLE
Add markdown URL format customization

### DIFF
--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -262,6 +262,11 @@ export class Plugin extends PluginBase<PluginTypes> {
       name = await getPastedFileName(this, new Substitutions(this.app, activeFile.path, makeFileName(name, extension)));
     }
 
-    return await next.call(this.app, name, extension, data);
+    const result = await next.call(this.app, name, extension, data);
+
+    result.path = await new Substitutions(this.app, result.path, result.name)
+      .fillTemplate(this.settings.markdownUrlFormat);
+
+    return result;
   }
 }

--- a/src/PluginSettings.ts
+++ b/src/PluginSettings.ts
@@ -24,6 +24,8 @@ export class PluginSettings {
   public generatedAttachmentFilename = 'file-${date:YYYYMMDDHHmmssSSS}';
   // eslint-disable-next-line no-magic-numbers
   public jpegQuality = 0.8;
+  // eslint-disable-next-line no-template-curly-in-string
+  public markdownUrlFormat = '${filePath}';
   public shouldConvertPastedImagesToJpeg = false;
   public shouldDeleteOrphanAttachments = false;
   public shouldRenameAttachmentFiles = false;

--- a/src/PluginSettingsTab.ts
+++ b/src/PluginSettingsTab.ts
@@ -62,6 +62,26 @@ export class PluginSettingsTab extends PluginSettingsTabBase<PluginTypes> {
       });
 
     new SettingEx(this.containerEl)
+      .setName('Markdown URL format')
+      .setDesc(createFragment((f) => {
+        f.appendText('Format for the URL that will be inserted into Markdown.');
+        f.createEl('br');
+        f.appendText('Note: You need to set ');
+        appendCodeBlock(f, 'Files & links > New link format');
+        f.appendText(' to ');
+        appendCodeBlock(f, 'Absolute path in vault');
+        f.appendText(' for URL rewriting to work.');
+        f.createEl('br');
+        f.appendText('See available ');
+        f.createEl('a', { href: 'https://github.com/RainCat1998/obsidian-custom-attachment-location?tab=readme-ov-file#tokens', text: 'tokens' });
+      }))
+      .addCodeHighlighter((codeHighlighter) => {
+        codeHighlighter.setLanguage(TOKENIZED_STRING_LANGUAGE);
+        codeHighlighter.inputEl.addClass('tokenized-string-setting-control');
+        this.bind(codeHighlighter, 'markdownUrlFormat');
+      });
+
+    new SettingEx(this.containerEl)
       .setName('Attachment rename mode')
       .setDesc(createFragment((f) => {
         f.appendText('When attaching files, ');


### PR DESCRIPTION
## Changes
Added a feature to customize the URL format that is inserted into markdown.

### How to Use
1. Set the URL format in the "Markdown URL format" setting
2. Set "Files & links > New link format" to "Absolute path in vault"

### Usage Examples
- `/${filePath}`: Generates a path starting with a slash. This format is useful for tools like [Zenn CLI](https://zenn.dev/zenn/articles/deploy-github-images#%E7%94%BB%E5%83%8F%E3%81%AE%E5%8F%82%E7%85%A7%E6%96%B9%E6%B3%95) that require paths starting with `/images/`.
- `https://cdn.example.com/${filePath}`: Allows placing the attachment folder at a specific URL. Particularly useful in environments where the attachment folder is synced with cloud storage.

![2025-05-14_02h21_43](https://github.com/user-attachments/assets/bb7f7941-e6a7-4bcc-80f5-083a8b4fb029)