### PR TITLE
add toggle for avoiding attachment duplication during collection.

### DIFF
--- a/src/AttachmentCollector.ts
+++ b/src/AttachmentCollector.ts
@@ -95,8 +95,12 @@ export async function collectAttachments(
       }
 
       const backlinks = await getBacklinksForFileSafe(app, attachmentMoveResult.oldAttachmentPath);
-      if (backlinks.count() > 1) {
-        attachmentMoveResult.newAttachmentPath = await copySafe(app, attachmentMoveResult.oldAttachmentPath, attachmentMoveResult.newAttachmentPath);
+      if (backlinks.keys().length > 1) {
+        if (plugin.settings.shouldDuplicateAttachments) {
+          attachmentMoveResult.newAttachmentPath = await copySafe(app, attachmentMoveResult.oldAttachmentPath, attachmentMoveResult.newAttachmentPath);
+        } else {
+          continue;
+        }
       } else {
         attachmentMoveResult.newAttachmentPath = await renameSafe(app, attachmentMoveResult.oldAttachmentPath, attachmentMoveResult.newAttachmentPath);
         await deleteEmptyFolderHierarchy(app, dirname(attachmentMoveResult.oldAttachmentPath));

--- a/src/PluginSettings.ts
+++ b/src/PluginSettings.ts
@@ -28,6 +28,7 @@ export class PluginSettings {
 
   public shouldConvertPastedImagesToJpeg = false;
   public shouldDeleteOrphanAttachments = false;
+  public shouldDuplicateAttachments = false;
   public shouldRenameAttachmentFiles = false;
   public shouldRenameAttachmentFolder = true;
   public shouldRenameAttachmentsToLowerCase = false;

--- a/src/PluginSettingsTab.ts
+++ b/src/PluginSettingsTab.ts
@@ -193,6 +193,18 @@ export class PluginSettingsTab extends PluginSettingsTabBase<PluginTypes> {
       });
 
     new SettingEx(this.containerEl)
+      .setName('Should duplicate collected attachments')
+      .setDesc('If enabled, when an attachment is linked by more than one note, a duplicate of the attachment is created for each note. When disabled, such attachments will not be processed by the plugin.')
+      .setDesc(createFragment((f) => {
+        f.appendText('If enabled, if an attachments processed via ');
+        appendCodeBlock(f, 'Collect attachments');
+        f.appendText(' commands has been linked by more than one note, a duplicate of the attachment will be created for each note according to the rules. When disabled, such attachments will not be processed by the plugin.');
+      }))
+      .addToggle((toggle) => {
+        this.bind(toggle, 'shouldDuplicateAttachments');
+      });
+
+    new SettingEx(this.containerEl)
       .setName('Duplicate name separator')
       .setDesc(createFragment((f) => {
         f.appendText('When you are pasting/dragging a file with the same name as an existing file, this separator will be added to the file name.');


### PR DESCRIPTION
My custom solution for #165 

Have tested on my local test repo (not thoroughly tested though)

Adds an option:

![image](https://github.com/user-attachments/assets/476b3c4b-9c4d-463a-b728-75669a206d35)

When turned off, it should achieve #165 . 

# Behaviors

## Same attachment linked across multiple files

Expected: nothing happens

Before collection:

![image](https://github.com/user-attachments/assets/33c8da4f-ed97-4ce5-bb08-c82ce1658efe)

After:

![image](https://github.com/user-attachments/assets/6b1d5a56-aac7-44fc-a94b-e9f58f966963)

## Same attachment linked multiple times in the same file

Expected: attachment moved to desired location without duplication

Before collection: 

![image](https://github.com/user-attachments/assets/9c9907b0-02df-470d-b108-851c6226c3bb)

After:

![image](https://github.com/user-attachments/assets/83b82c54-7ca3-4567-88c0-7b035072ba10)

---

Some worries about what I did:

[AttachmentCollector.ts:98](https://github.com/Accelsnow/obsidian-custom-attachment-location/blob/c1d50a3deb21112cec8bd5131cff2482d30e3bfe/src/AttachmentCollector.ts#L98C7-L98C41)
I changed from `backlinks.count() > 1` to `backlinks.keys().length > 1`. backlink is a map where the keys are note filenames, and values are lists to locations where the note links the attachment. If there is only one key, it implies that there is only one file linking the attachment. In this case, we should be able to just relocate it without copying it. If there is more than one key, then there is more than one file linking the attachment. Depending on the added toggle option, we can skip processing current attachment.
