### PR TITLE
Remove invalid filesystem characters from headings

### DIFF
--- a/src/Substitutions.ts
+++ b/src/Substitutions.ts
@@ -472,7 +472,8 @@ export class Substitutions {
     }
 
     const headingsInfo = await this.initHeadings();
-    return headingsInfo.get(format as HeadingLevel) ?? '';
+    const heading = headingsInfo.get(format as HeadingLevel) ?? '';
+    return obsidian.stripHeading(heading);
   }
 
   private async initHeadings(): Promise<Map<HeadingLevel, string>> {


### PR DESCRIPTION
For instance, < or > are not allowed on Windows filesystems.