### PR TITLE
feat: add 'Collect attachment' item to file menu

### DIFF
--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -91,6 +91,7 @@ import {
 import type { PluginTypes } from './PluginTypes.ts';
 
 import {
+  collectAttachment,
   collectAttachmentsCurrentFolder,
   collectAttachmentsCurrentNote,
   collectAttachmentsEntireVault,
@@ -555,6 +556,13 @@ export class Plugin extends PluginBase<PluginTypes> {
 
   private handleFileMenu(menu: Menu, file: TAbstractFile): void {
     if (!(file instanceof TFolder)) {
+      if (file instanceof TFile && !isNote(this.app, file.path)) {
+        menu.addItem((item) => {
+          item.setTitle(t(($) => $.menuItems.collectAttachment))
+            .setIcon('download')
+            .onClick(() => collectAttachment(this, file, this.abortSignal));
+        });
+      }
       return;
     }
 

--- a/src/i18n/locales/default.ts
+++ b/src/i18n/locales/default.ts
@@ -32,15 +32,18 @@ export const defaultTranslations = {
     collectAttachmentsEntireVault: 'Collect attachments in entire vault'
   },
   menuItems: {
-    collectAttachmentsInFolder: 'Collect attachments in folder'
+    collectAttachmentsInFolder: 'Collect attachments in folder',
+    collectAttachment: 'Collect attachment'
   },
   notice: {
+    attachmentAlreadyInCorrectLocation: 'Attachment is already in the correct location',
     collectingAttachments: 'Collecting attachments for \'{{noteFilePath}}\'',
     collectingAttachmentsCancelled: 'Collecting attachments cancelled. See console for details.',
     generatedAttachmentFileNameIsInvalid: {
       part1: 'Generated attachment file name \'{{path}}\' is invalid.\n{{validationMessage}}\nCheck your',
       part2: 'setting.'
     },
+    movedAttachmentTo: 'Moved attachment to: {{newAttachmentPath}}',
     notePathIsIgnored: 'Note path is ignored'
   },
   obsidianDevUtils: {


### PR DESCRIPTION
The plugin registers a menu item for collecting attachments in the folder context menu.  
To make it more convenient, this PR adds a similar menu item for the file context menu, allowing collection of a single attachment.

The new feature is mainly implemented through a newly-created function collectAttachment() in src/AttachmentCollector.ts, which largely mimics the logic of prepareAttachmentToMove() in same file.

This feature keeps other logic in the plugin completely untouched.

As a implemetation detail,orphan attachment can be renamed and relocated normally as long as the rename logic does not require noteFilePath. This is mainly realized by: `const noteFilePath = backlinkPaths.length > 0 ? backlinkPaths[0] ?? '' : '';`, similar to `noteFilePath: this.app.workspace.getActiveFile()?.path ?? '',` in importFiles() function in src/Plugin.ts

Test screenshot for relocating orphan attachment:
<img width="1790" height="1147" alt="20251213_21110500+09_screen" src="https://github.com/user-attachments/assets/17e13982-25d2-4897-9281-0b3ee22768d8" />
<img width="1947" height="407" alt="20251213_21111700+09_screen" src="https://github.com/user-attachments/assets/b44d86e9-f930-42fd-ad19-f8199df6c108" />


This PR is based on commit 0cb8944, so the setting page problem(#255) also exists in this PR.